### PR TITLE
[auto-merge] branch-0.2 to branch-0.3 [skip ci] [bot]

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Update CHANGELOG.md
         id: upt
         #run: echo "::set-output name=stdout::$(.github/workflows/changelog/changelog --base_refs=branch-0.1,branch-0.2,branch-0.3)"
-        if: github.ref == 'refs/heads/branch-0.2' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true))
+        if: ${{ github.ref == 'refs/heads/branch-0.2' && github.event.pull_request.merged == true }}
         uses: ./.github/workflows/changelog
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
@@ -41,7 +41,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Create PR
-        if: ${{ success() && github.ref == 'refs/heads/branch-0.2' && (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)) }}
+        if: ${{ github.ref == 'refs/heads/branch-0.2' && github.event.pull_request.merged == true }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-0.2` to create a PR keeping `branch-0.3` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.