### PR TITLE
[DOC] Changelog update 2020-08-25 [skip ci] [bot]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Generated on 2020-08-25
 ### Bugs Fixed
 |||
 |:---|:---|
+|[#598](https://github.com/NVIDIA/spark-rapids/issues/598)|[BUG] Non-deterministic output from MapOutputTracker.getStatistics() with AQE on GPU|
 |[#192](https://github.com/NVIDIA/spark-rapids/issues/192)|[BUG] test_read_merge_schema fails on Databricks|
 |[#569](https://github.com/NVIDIA/spark-rapids/issues/569)|[BUG] left_semi_join operation is abnormal and serious time-consuming|
 |[#341](https://github.com/NVIDIA/spark-rapids/issues/341)|[BUG] Document compression formats for readers/writers|


### PR DESCRIPTION
changelog-gen runs on 2020-08-25

check script stdout: [job_run_223225484](https://github.com/pxLi/spark-rapids/actions/runs/223225484)

Please review the generated CHANGELOG.md, then merge or close the PR and feel free to **delete** the remote branch.