### PR TITLE
[auto-merge] branch-0.2 to branch-0.3 [skip ci] [bot]

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,6 +28,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: branch-0.2 # fetch from latest upstream instead of PR ref
+
 
       - name: auto-merge job
         uses: ./.github/workflows/auto-merge

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 # 20
 # 21
 # 22
+# 23
 # RAPIDS Accelerator For Apache Spark
 NOTE: For the latest stable [README.md](https://github.com/nvidia/spark-rapids/blob/main/README.md) ensure you are on the main branch. The RAPIDS Accelerator for Apache Spark provides a set of plugins for Apache Spark that leverage GPUs to accelerate processing via the RAPIDS libraries and UCX. Documentation on the current release can be found [here](https://nvidia.github.io/spark-rapids/). 
 


### PR DESCRIPTION
auto-merge triggered by github actions on `branch-0.2` to create a PR keeping `branch-0.3` up-to-date. If this PR is unable to be merged due to conflicts, it will remain open until manually fix.