### PR TITLE
Fix missed gnupg2 in ucx example dockerfiles

### DIFF
--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_no_rdma
@@ -29,6 +29,7 @@ FROM nvidia/cuda:${CUDA_VER}-runtime-ubuntu18.04
 ARG UCX_VER
 ARG UCX_CUDA_VER
 
+RUN apt-get update && apt-get install -y gnupg2
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 

--- a/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
+++ b/docs/additional-functionality/shuffle-docker-examples/Dockerfile.ubuntu_rdma
@@ -36,6 +36,7 @@ ARG UCX_CUDA_VER=11
 FROM ubuntu:18.04 as rdma_core
 ARG RDMA_CORE_VERSION
 
+RUN apt-get update && apt-get install -y gnupg2
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 RUN apt update && apt install -y dh-make wget build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev ninja-build pkg-config valgrind python3-dev cython3 python3-docutils pandoc


### PR DESCRIPTION
Fixes #xxxx.

### Description

xyz test

### Checklists

- [ ] This PR has added documentation for new or modified features or behaviors.
- [ ] This PR has added new tests or modified existing tests to cover new code paths.
      (Please explain in the PR description how the new code paths are tested, such as names of the new/existing tests that cover them.)
- [ ] Performance testing has been performed and its results are added in the PR description. Or, an issue has been filed with a link in the PR description.

- [ ] All GPU resources (`ColumnarBatch`, `GpuColumnVector`, etc.) use `withResource`/`closeOnExcept` — no bare `.close()`.
- [ ] If shim files were modified, all related Spark version shims are updated consistently.
- [ ] If `pom.xml` was modified, `./build/make-scala-version-build-files.sh 2.13` has been run to sync Scala 2.13 pom files.
- [ ] If new `RapidsConf` keys were added, they have documentation and sensible defaults.
- [ ] If new GPU operators were added, they are registered in `GpuOverrides` with proper fallback declarations.
- [ ] If this PR affects Databricks-specific code, `[databricks]` is in the PR title.
- [ ] If SNAPSHOT dependency versions were changed, the rationale is described above.

### 